### PR TITLE
Fix GFLIP_LIBRARIES

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -7,5 +7,5 @@
 set(GFLIP_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include/gflip)
 
 foreach(lib gflip vocabulary)
-    list(APPEND FLIRT_LIBRARIES @CMAKE_INSTALL_PREFIX@/lib/gflip/lib${lib}.so)
+    list(APPEND GFLIP_LIBRARIES @CMAKE_INSTALL_PREFIX@/lib/libgflip_${lib}.so)
 endforeach()

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -4,8 +4,8 @@
 #  @CMAKE_PROJECT_NAME@_INCLUDE_DIRS - Include directories for @CMAKE_PROJECT_NAME@
 #  @CMAKE_PROJECT_NAME@_LIBRARIES    - Libraries for @CMAKE_PROJECT_NAME@
 
-set(GFLIP_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include/gflip)
+set(gflip_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include/gflip)
 
 foreach(lib gflip vocabulary)
-    list(APPEND GFLIP_LIBRARIES @CMAKE_INSTALL_PREFIX@/lib/libgflip_${lib}.so)
+    list(APPEND gflip_LIBRARIES @CMAKE_INSTALL_PREFIX@/lib/libgflip_${lib}.so)
 endforeach()

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -3,12 +3,12 @@ TARGET_LINK_LIBRARIES(featureExtractor ${FLIRT_LIBRARIES} ${Boost_LIBRARIES})
 ADD_DEPENDENCIES(featureExtractor flirt)
 
 ADD_EXECUTABLE(learnVocabularyKMeans LearnVocabularyKMeans.cpp)
-TARGET_LINK_LIBRARIES(learnVocabularyKMeans ${FLIRT_LIBRARIES}  vocabulary ${Boost_LIBRARIES})
+TARGET_LINK_LIBRARIES(learnVocabularyKMeans ${FLIRT_LIBRARIES} gflip_vocabulary ${Boost_LIBRARIES})
 ADD_DEPENDENCIES(learnVocabularyKMeans flirt)
 ##SET_SOURCE_FILES_PROPERTIES(LearnVocabularyKMeans.cpp PROPERTIES COMPILE_FLAGS "-O0 -ggdb ")
 
 ADD_EXECUTABLE(generateBoW GenerateBoW.cpp)
-TARGET_LINK_LIBRARIES(generateBoW vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES})
+TARGET_LINK_LIBRARIES(generateBoW gflip_vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES})
 ADD_DEPENDENCIES(generateBoW flirt)
 
 ADD_EXECUTABLE(nnLoopClosingTest NNLoopClosingTest.cpp)
@@ -17,20 +17,20 @@ ADD_DEPENDENCIES(nnLoopClosingTest flirt)
 #SET_SOURCE_FILES_PROPERTIES(NNLoopClosingTest.cpp PROPERTIES COMPILE_FLAGS "-O0 -ggdb ")
 
 ADD_EXECUTABLE(generateNN GenerateNN.cpp)
-TARGET_LINK_LIBRARIES(generateNN vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES} gflip )
+TARGET_LINK_LIBRARIES(generateNN gflip_vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES} gflip_gflip)
 ADD_DEPENDENCIES(generateNN flirt)
 #SET_SOURCE_FILES_PROPERTIES(NNLoopClosingTest.cpp PROPERTIES COMPILE_FLAGS "-O0 -ggdb ")
 
 ADD_EXECUTABLE(GFPLoopClosingTest GFPLoopClosingTest.cpp)
-TARGET_LINK_LIBRARIES(GFPLoopClosingTest vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES} gflip )
+TARGET_LINK_LIBRARIES(GFPLoopClosingTest gflip_vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES} gflip_gflip)
 ADD_DEPENDENCIES(GFPLoopClosingTest flirt)
 #SET_SOURCE_FILES_PROPERTIES(NNLoopClosingTest.cpp PROPERTIES COMPILE_FLAGS "-O0 -ggdb ")
 
 ADD_EXECUTABLE(gflip_cl gflip_cl.cpp)
-TARGET_LINK_LIBRARIES(gflip_cl gflip)
+TARGET_LINK_LIBRARIES(gflip_cl gflip_gflip)
 
 ADD_EXECUTABLE(gflip_cl_onequery gflip_cl_onequery.cpp)
-TARGET_LINK_LIBRARIES(gflip_cl_onequery gflip)
+TARGET_LINK_LIBRARIES(gflip_cl_onequery gflip_gflip)
 
 install(TARGETS featureExtractor learnVocabularyKMeans generateBoW nnLoopClosingTest generateNN GFPLoopClosingTest gflip_cl gflip_cl_onequery
     RUNTIME DESTINATION bin

--- a/src/gflip/CMakeLists.txt
+++ b/src/gflip/CMakeLists.txt
@@ -1,12 +1,13 @@
-SET(gflip_SRCS 
+set(gflip_SRCS
   gflip_engine.cpp
-) 
+)
 
-SET(gflip_HDRS 
+set(gflip_HDRS
   gflip_engine.hpp
-) 
+)
 
-ADD_LIBRARY(gflip_gflip SHARED ${gflip_SRCS})
+add_library(gflip_gflip SHARED ${gflip_SRCS})
+target_link_libraries(gflip_gflip ${Boost_LIBRARIES})
 
 install(TARGETS gflip_gflip
     RUNTIME DESTINATION bin

--- a/src/gflip/CMakeLists.txt
+++ b/src/gflip/CMakeLists.txt
@@ -6,11 +6,11 @@ SET(gflip_HDRS
   gflip_engine.hpp
 ) 
 
-ADD_LIBRARY(gflip SHARED ${gflip_SRCS})
+ADD_LIBRARY(gflip_gflip SHARED ${gflip_SRCS})
 
-install(TARGETS gflip
+install(TARGETS gflip_gflip
     RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib/${PROJECT_NAME}
-    ARCHIVE DESTINATION lib/${PROJECT_NAME})
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
 
 install(FILES ${gflip_HDRS} DESTINATION include/${PROJECT_NAME}/gflip)

--- a/src/vocabulary/CMakeLists.txt
+++ b/src/vocabulary/CMakeLists.txt
@@ -10,12 +10,12 @@ SET(vocabulary_HDRS
   Vocabulary.h
 ) 
 
-ADD_LIBRARY(vocabulary SHARED ${vocabulary_SRCS})
-TARGET_LINK_LIBRARIES(vocabulary ${FLIRT_LIBRARIES})
+ADD_LIBRARY(gflip_vocabulary SHARED ${vocabulary_SRCS})
+TARGET_LINK_LIBRARIES(gflip_vocabulary ${FLIRT_LIBRARIES})
 
-install(TARGETS vocabulary
+install(TARGETS gflip_vocabulary
     RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib/${PROJECT_NAME}
-    ARCHIVE DESTINATION lib/${PROJECT_NAME})
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
 
 install(FILES ${vocabulary_HDRS} DESTINATION include/${PROJECT_NAME}/vocabulary)

--- a/src/vocabulary/CMakeLists.txt
+++ b/src/vocabulary/CMakeLists.txt
@@ -1,17 +1,17 @@
-SET(vocabulary_SRCS 
+set(vocabulary_SRCS
   Vocabulary.cpp
-) 
+)
 
-SET(vocabulary_HDRS 
+set(vocabulary_HDRS
   HierarchicalKMeansClustering.h
   HierarchicalKMeansClustering.hpp
   KMeansClustering.h
   KMeansClustering.hpp
   Vocabulary.h
-) 
+)
 
-ADD_LIBRARY(gflip_vocabulary SHARED ${vocabulary_SRCS})
-TARGET_LINK_LIBRARIES(gflip_vocabulary ${FLIRT_LIBRARIES})
+add_library(gflip_vocabulary SHARED ${vocabulary_SRCS})
+target_link_libraries(gflip_vocabulary ${FLIRT_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS gflip_vocabulary
     RUNTIME DESTINATION bin


### PR DESCRIPTION
There were two bugs:
1. `FLIRT_LIBRARIES` instead of `GFLIP_LIBRARIES`
2. ROS doesn't find libraries nested inside the `lib` folder, so instead of `gflip/lib${lib}.so`, the libraries must use a prefix like `libgflip_${lib}.so`

This might not solve all the issues yet.
