### PR TITLE
Make config module relocatable.

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -4,8 +4,8 @@
 #  @CMAKE_PROJECT_NAME@_INCLUDE_DIRS - Include directories for @CMAKE_PROJECT_NAME@
 #  @CMAKE_PROJECT_NAME@_LIBRARIES    - Libraries for @CMAKE_PROJECT_NAME@
 
-set(gflip_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include/gflip)
+set(gflip_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../../include/)
 
 foreach(lib gflip vocabulary)
-    list(APPEND gflip_LIBRARIES @CMAKE_INSTALL_PREFIX@/lib/libgflip_${lib}.so)
+  list(APPEND gflip_LIBRARIES ${CMAKE_CURRENT_LIST_DIR}/../../../lib/libgflip_${lib}.so)
 endforeach()


### PR DESCRIPTION
This is important for DESTDIR builds.
